### PR TITLE
add fardin to codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @Tradeshift/developer-productivity
+* @Tradeshift/developer-productivity @fardin01


### PR DESCRIPTION
Fardin will be heading the move to ECR initiative, and might need to do quite a few changes in here. Let's make him codeowner.