### PR TITLE
Add a default tag

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -17,7 +17,11 @@ jobs:
             npm-
       - run: |
           npm ci
-          npm run all
+          npm run build
+          npm run format-check
+          npm run lint
+          npm run package
+          npm run test
 
   sonarqube:
     runs-on: self-hosted
@@ -31,7 +35,10 @@ jobs:
           key: npm-${{ hashFiles('package-lock.json') }}
           restore-keys: |
             npm-
-      - run: npm ci
+      - run: |
+          npm ci
+          npm run build
+          npm run test
       - uses: tradeshift/actions-sonarqube/scanner@v1
         with:
           caCert: ${{ secrets.MTLS_CACERT }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -16,7 +16,11 @@ jobs:
             npm-
       - run: |
           npm ci
-          npm run all
+          npm run build
+          npm run format-check
+          npm run lint
+          npm run package
+          npm run test
 
   sonarqube:
     runs-on: self-hosted
@@ -30,7 +34,10 @@ jobs:
           key: npm-${{ hashFiles('package-lock.json') }}
           restore-keys: |
             npm-
-      - run: npm ci
+      - run: |
+          npm ci
+          npm run build
+          npm run test
       - uses: tradeshift/actions-sonarqube/scanner@v1
         with:
           caCert: ${{ secrets.MTLS_CACERT }}

--- a/__tests__/docker.test.ts
+++ b/__tests__/docker.test.ts
@@ -1,0 +1,35 @@
+import {getRegistry, isDockerhubRepository} from '../src/docker';
+
+describe(isDockerhubRepository, () => {
+  it('returns true when given a dockerhub repository', () => {
+    expect(isDockerhubRepository('test')).toEqual(true);
+    expect(isDockerhubRepository('test/test')).toEqual(true);
+    expect(isDockerhubRepository('test/test/test')).toEqual(true);
+  });
+
+  it('returns false when given a non-dockerhub repository', () => {
+    expect(isDockerhubRepository('test.com')).toEqual(false);
+    expect(isDockerhubRepository('test.com/test')).toEqual(false);
+    expect(isDockerhubRepository('test.com/test/test')).toEqual(false);
+  });
+});
+
+describe(getRegistry, () => {
+  it('returns empty string when dockerhub', async () => {
+    expect(getRegistry('test')).toEqual('');
+    expect(getRegistry('test/test')).toEqual('');
+    expect(getRegistry('test/test/test')).toEqual('');
+  });
+
+  it('detects other registries', async () => {
+    expect(getRegistry('test.com')).toEqual('test.com');
+    expect(getRegistry('test.com/com')).toEqual('test.com');
+    expect(getRegistry('test.com/test/test')).toEqual('test.com');
+  });
+
+  it('throws error if registry cannot be determined', () => {
+    expect(() => getRegistry('')).toThrow();
+    expect(() => getRegistry('/test')).toThrow();
+    expect(() => getRegistry('_test')).toThrow();
+  });
+});

--- a/action.yml
+++ b/action.yml
@@ -2,17 +2,9 @@ name: 'docker action'
 description: 'does auth, build and push'
 author: 'Tradeshift'
 inputs:
-  username:
+  build-args:
     required: false
-    description: docker registry username
-    default: _json_key
-  password:
-    required: false
-    description: docker registry password
-  registry:
-    required: true
-    description: docker registry
-    default: eu.gcr.io
+    description: list of build args
   context:
     required: true
     description: docker context
@@ -23,13 +15,27 @@ inputs:
   labels:
     required: false
     description: list of labels
-  tags:
+  password:
     required: false
-    description: list of tags
+    description: >
+      Password for docker registry detected from the repository.
   push:
     required: false
     description: wether to push or not
     default: "true"
+  repository:
+    required: false
+    description: >
+      The repository where default tags will be pushed. If not specified this
+      will default to eu.gcr.io/tradeshift-base/<repo-name>
+  tags:
+    required: false
+    description: list of tags
+  username:
+    required: false
+    description: >
+      Username for docker registry detected from the repository.
+    default: _json_key
 runs:
   using: 'node12'
   main: 'dist/index.js'

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   clearMocks: true,
+  collectCoverage: true,
   moduleFileExtensions: ['js', 'ts'],
   testEnvironment: 'node',
   testMatch: ['**/*.test.ts'],

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,17 @@
         "@actions/io": "^1.0.1"
       }
     },
+    "@actions/github": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@actions/github/-/github-4.0.0.tgz",
+      "integrity": "sha512-Ej/Y2E+VV6sR9X7pWL5F3VgEWrABaT292DRqRU6R4hnQjPtC/zD3nagxVdXWiRQvYDh8kHXo7IDmG42eJ/dOMA==",
+      "requires": {
+        "@actions/http-client": "^1.0.8",
+        "@octokit/core": "^3.0.0",
+        "@octokit/plugin-paginate-rest": "^2.2.3",
+        "@octokit/plugin-rest-endpoint-methods": "^4.0.0"
+      }
+    },
     "@actions/http-client": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-1.0.9.tgz",
@@ -1200,6 +1211,117 @@
         "fastq": "^1.6.0"
       }
     },
+    "@octokit/auth-token": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.4.5.tgz",
+      "integrity": "sha512-BpGYsPgJt05M7/L/5FoE1PiAbdxXFZkX/3kDYcsvd1v6UhlnE5e96dTDr0ezX/EFwciQxf3cNV0loipsURU+WA==",
+      "requires": {
+        "@octokit/types": "^6.0.3"
+      }
+    },
+    "@octokit/core": {
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.2.5.tgz",
+      "integrity": "sha512-+DCtPykGnvXKWWQI0E1XD+CCeWSBhB6kwItXqfFmNBlIlhczuDPbg+P6BtLnVBaRJDAjv+1mrUJuRsFSjktopg==",
+      "requires": {
+        "@octokit/auth-token": "^2.4.4",
+        "@octokit/graphql": "^4.5.8",
+        "@octokit/request": "^5.4.12",
+        "@octokit/types": "^6.0.3",
+        "before-after-hook": "^2.1.0",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "@octokit/endpoint": {
+      "version": "6.0.11",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.11.tgz",
+      "integrity": "sha512-fUIPpx+pZyoLW4GCs3yMnlj2LfoXTWDUVPTC4V3MUEKZm48W+XYpeWSZCv+vYF1ZABUm2CqnDVf1sFtIYrj7KQ==",
+      "requires": {
+        "@octokit/types": "^6.0.3",
+        "is-plain-object": "^5.0.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "dependencies": {
+        "is-plain-object": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+          "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q=="
+        }
+      }
+    },
+    "@octokit/graphql": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.6.0.tgz",
+      "integrity": "sha512-CJ6n7izLFXLvPZaWzCQDjU/RP+vHiZmWdOunaCS87v+2jxMsW9FB5ktfIxybRBxZjxuJGRnxk7xJecWTVxFUYQ==",
+      "requires": {
+        "@octokit/request": "^5.3.0",
+        "@octokit/types": "^6.0.3",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "@octokit/openapi-types": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-4.0.1.tgz",
+      "integrity": "sha512-k2hRcfcLRyPJjtYfJLzg404n7HZ6sUpAWAR/uNI8tf96NgatWOpw1ocdF+WFfx/trO1ivBh7ckynO1rn+xAw/Q=="
+    },
+    "@octokit/plugin-paginate-rest": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.9.1.tgz",
+      "integrity": "sha512-8wnuWGjwDIEobbBet2xAjZwgiMVTgIer5wBsnGXzV3lJ4yqphLU2FEMpkhSrDx7y+WkZDfZ+V+1cFMZ1mAaFag==",
+      "requires": {
+        "@octokit/types": "^6.8.0"
+      }
+    },
+    "@octokit/plugin-rest-endpoint-methods": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-4.10.1.tgz",
+      "integrity": "sha512-YGMiEidTORzgUmYZu0eH4q2k8kgQSHQMuBOBYiKxUYs/nXea4q/Ze6tDzjcRAPmHNJYXrENs1bEMlcdGKT+8ug==",
+      "requires": {
+        "@octokit/types": "^6.8.2",
+        "deprecation": "^2.3.1"
+      }
+    },
+    "@octokit/request": {
+      "version": "5.4.14",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.4.14.tgz",
+      "integrity": "sha512-VkmtacOIQp9daSnBmDI92xNIeLuSRDOIuplp/CJomkvzt7M18NXgG044Cx/LFKLgjKt9T2tZR6AtJayba9GTSA==",
+      "requires": {
+        "@octokit/endpoint": "^6.0.1",
+        "@octokit/request-error": "^2.0.0",
+        "@octokit/types": "^6.7.1",
+        "deprecation": "^2.0.0",
+        "is-plain-object": "^5.0.0",
+        "node-fetch": "^2.6.1",
+        "once": "^1.4.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "dependencies": {
+        "is-plain-object": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+          "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q=="
+        }
+      }
+    },
+    "@octokit/request-error": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.0.5.tgz",
+      "integrity": "sha512-T/2wcCFyM7SkXzNoyVNWjyVlUwBvW3igM3Btr/eKYiPmucXTtkxt2RBsf6gn3LTzaLSLTQtNmvg+dGsOxQrjZg==",
+      "requires": {
+        "@octokit/types": "^6.0.3",
+        "deprecation": "^2.0.0",
+        "once": "^1.4.0"
+      }
+    },
+    "@octokit/types": {
+      "version": "6.8.2",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.8.2.tgz",
+      "integrity": "sha512-RpG0NJd7OKSkWptiFhy1xCLkThs5YoDIKM21lEtDmUvSpbaIEfrxzckWLUGDFfF8RydSyngo44gDv8m2hHruUg==",
+      "requires": {
+        "@octokit/openapi-types": "^4.0.0",
+        "@types/node": ">= 8"
+      }
+    },
     "@sinonjs/commons": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.1.tgz",
@@ -1317,8 +1439,7 @@
     "@types/node": {
       "version": "14.14.25",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.25.tgz",
-      "integrity": "sha512-EPpXLOVqDvisVxtlbvzfyqSsFeQxltFbluZNRndIb8tr9KiBnYNLzrc1N3pyKUCww2RNrfHDViqDWWE1LCJQtQ==",
-      "dev": true
+      "integrity": "sha512-EPpXLOVqDvisVxtlbvzfyqSsFeQxltFbluZNRndIb8tr9KiBnYNLzrc1N3pyKUCww2RNrfHDViqDWWE1LCJQtQ=="
     },
     "@types/normalize-package-data": {
       "version": "2.4.0",
@@ -2002,6 +2123,11 @@
         "tweetnacl": "^0.14.3"
       }
     },
+    "before-after-hook": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.1.1.tgz",
+      "integrity": "sha512-5ekuQOvO04MDj7kYZJaMab2S8SPjGJbotVNyv7QYFCOAwrGZs/YnoDNlh1U+m5hl7H2D/+n0taaAV/tfyd3KMA=="
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -2457,6 +2583,11 @@
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true
+    },
+    "deprecation": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
+      "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ=="
     },
     "detect-newline": {
       "version": "3.1.0",
@@ -6462,6 +6593,11 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
     },
+    "node-fetch": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+    },
     "node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -6693,7 +6829,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -8180,6 +8315,11 @@
         "set-value": "^2.0.1"
       }
     },
+    "universal-user-agent": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
+      "integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w=="
+    },
     "unset-value": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
@@ -8435,8 +8575,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "write-file-atomic": {
       "version": "3.0.3",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@actions/core": "^1.2.6",
     "@actions/exec": "^1.0.4",
+    "@actions/github": "^4.0.0",
     "@actions/http-client": "^1.0.9",
     "@actions/tool-cache": "^1.6.1",
     "csv-parse": "^4.15.1",

--- a/src/inputs.ts
+++ b/src/inputs.ts
@@ -2,30 +2,28 @@ import csvparse from 'csv-parse/lib/sync';
 import {getInput} from '@actions/core';
 
 export interface Inputs {
-  // login inputs
-  username: string;
-  password: string;
-  registry: string;
-  // build / push inputs
+  buildArgs: string[];
   context: string;
   file: string;
   labels: string[];
-  buildArgs: string[];
-  tags: string[];
+  password: string;
   push: boolean;
+  repository: string;
+  tags: string[];
+  username: string;
 }
 
 export async function getInputs(): Promise<Inputs> {
   return {
-    username: getInput('username'),
-    password: getInput('password'),
-    registry: getInput('registry'),
+    buildArgs: await getInputList('build-args'),
     context: getInput('context'),
     file: getInput('file'),
     labels: await getInputList('labels'),
-    buildArgs: await getInputList('build-args'),
+    password: getInput('password'),
+    push: /true/i.test(getInput('push')),
+    repository: getInput('repository'),
     tags: await getInputList('tags'),
-    push: /true/i.test(getInput('push'))
+    username: getInput('username')
   };
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,7 +13,7 @@ async function run(): Promise<void> {
     state.setIsPost();
 
     const inputs = await getInputs();
-    await docker.login(inputs.registry, inputs.username, inputs.password);
+    await docker.login(inputs.repository, inputs.username, inputs.password);
     await buildx.setup();
     await docker.build(inputs);
   } catch (error) {


### PR DESCRIPTION
This will add a SHA tag to the docker image by default.

In order to do this we need to introduce a new input `repository` this
input is optional and defaults to
`eu.gcr.io/tradeshift-base/<repo-name>`. The value of the repository
input will be used to make a default tag of the commit SHA.

The new input makes the `registry` input unessesary, as we can easily
determine the registry from the `repository` input. Therefore we also
remove the `registry` input.

As we have some tests in here I wen't ahead and enabled coverage reports
for sonarqube as well.