### PR TITLE
chore: update dependency tree

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -261,9 +261,9 @@
       "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
     "node_modules/@azure/core-lro": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/@azure/core-lro/-/core-lro-2.2.3.tgz",
-      "integrity": "sha512-UMdlR9NsqDCLTba3EUbRjfMF4gDmWvld196JmUjbz9WWhJ2XT00OR5MXeWiR+vmGT+ETiO4hHFCi2/eGO5YVtg==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/@azure/core-lro/-/core-lro-2.2.4.tgz",
+      "integrity": "sha512-e1I2v2CZM0mQo8+RSix0x091Av493e4bnT22ds2fcQGslTHzM2oTbswkB65nP4iEpCxBrFxOSDPKExmTmjCVtQ==",
       "dependencies": {
         "@azure/abort-controller": "^1.0.0",
         "@azure/core-tracing": "1.0.0-preview.13",
@@ -1728,14 +1728,14 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "5.13.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.13.0.tgz",
-      "integrity": "sha512-vLktb2Uec81fxm/cfz2Hd6QaWOs8qdmVAZXLdOBX6JFJDhf6oDZpMzZ4/LZ6SFM/5DgDcxIMIvy3F+O9yZBuiQ==",
+      "version": "5.14.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.14.0.tgz",
+      "integrity": "sha512-ir0wYI4FfFUDfLcuwKzIH7sMVA+db7WYen47iRSaCGl+HMAZI9fpBwfDo45ZALD3A45ZGyHWDNLhbg8tZrMX4w==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.13.0",
-        "@typescript-eslint/type-utils": "5.13.0",
-        "@typescript-eslint/utils": "5.13.0",
+        "@typescript-eslint/scope-manager": "5.14.0",
+        "@typescript-eslint/type-utils": "5.14.0",
+        "@typescript-eslint/utils": "5.14.0",
         "debug": "^4.3.2",
         "functional-red-black-tree": "^1.0.1",
         "ignore": "^5.1.8",
@@ -1761,14 +1761,14 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "5.13.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.13.0.tgz",
-      "integrity": "sha512-GdrU4GvBE29tm2RqWOM0P5QfCtgCyN4hXICj/X9ibKED16136l9ZpoJvCL5pSKtmJzA+NRDzQ312wWMejCVVfg==",
+      "version": "5.14.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.14.0.tgz",
+      "integrity": "sha512-aHJN8/FuIy1Zvqk4U/gcO/fxeMKyoSv/rS46UXMXOJKVsLQ+iYPuXNbpbH7cBLcpSbmyyFbwrniLx5+kutu1pw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.13.0",
-        "@typescript-eslint/types": "5.13.0",
-        "@typescript-eslint/typescript-estree": "5.13.0",
+        "@typescript-eslint/scope-manager": "5.14.0",
+        "@typescript-eslint/types": "5.14.0",
+        "@typescript-eslint/typescript-estree": "5.14.0",
         "debug": "^4.3.2"
       },
       "engines": {
@@ -1788,13 +1788,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.13.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.13.0.tgz",
-      "integrity": "sha512-T4N8UvKYDSfVYdmJq7g2IPJYCRzwtp74KyDZytkR4OL3NRupvswvmJQJ4CX5tDSurW2cvCc1Ia1qM7d0jpa7IA==",
+      "version": "5.14.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.14.0.tgz",
+      "integrity": "sha512-LazdcMlGnv+xUc5R4qIlqH0OWARyl2kaP8pVCS39qSL3Pd1F7mI10DbdXeARcE62sVQE4fHNvEqMWsypWO+yEw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.13.0",
-        "@typescript-eslint/visitor-keys": "5.13.0"
+        "@typescript-eslint/types": "5.14.0",
+        "@typescript-eslint/visitor-keys": "5.14.0"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -1805,12 +1805,12 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "5.13.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.13.0.tgz",
-      "integrity": "sha512-/nz7qFizaBM1SuqAKb7GLkcNn2buRdDgZraXlkhz+vUGiN1NZ9LzkA595tHHeduAiS2MsHqMNhE2zNzGdw43Yg==",
+      "version": "5.14.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.14.0.tgz",
+      "integrity": "sha512-d4PTJxsqaUpv8iERTDSQBKUCV7Q5yyXjqXUl3XF7Sd9ogNLuKLkxz82qxokqQ4jXdTPZudWpmNtr/JjbbvUixw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/utils": "5.13.0",
+        "@typescript-eslint/utils": "5.14.0",
         "debug": "^4.3.2",
         "tsutils": "^3.21.0"
       },
@@ -1831,9 +1831,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "5.13.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.13.0.tgz",
-      "integrity": "sha512-LmE/KO6DUy0nFY/OoQU0XelnmDt+V8lPQhh8MOVa7Y5k2gGRd6U9Kp3wAjhB4OHg57tUO0nOnwYQhRRyEAyOyg==",
+      "version": "5.14.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.14.0.tgz",
+      "integrity": "sha512-BR6Y9eE9360LNnW3eEUqAg6HxS9Q35kSIs4rp4vNHRdfg0s+/PgHgskvu5DFTM7G5VKAVjuyaN476LCPrdA7Mw==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -1844,13 +1844,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.13.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.13.0.tgz",
-      "integrity": "sha512-Q9cQow0DeLjnp5DuEDjLZ6JIkwGx3oYZe+BfcNuw/POhtpcxMTy18Icl6BJqTSd+3ftsrfuVb7mNHRZf7xiaNA==",
+      "version": "5.14.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.14.0.tgz",
+      "integrity": "sha512-QGnxvROrCVtLQ1724GLTHBTR0lZVu13izOp9njRvMkCBgWX26PKvmMP8k82nmXBRD3DQcFFq2oj3cKDwr0FaUA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.13.0",
-        "@typescript-eslint/visitor-keys": "5.13.0",
+        "@typescript-eslint/types": "5.14.0",
+        "@typescript-eslint/visitor-keys": "5.14.0",
         "debug": "^4.3.2",
         "globby": "^11.0.4",
         "is-glob": "^4.0.3",
@@ -1871,15 +1871,15 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "5.13.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.13.0.tgz",
-      "integrity": "sha512-+9oHlPWYNl6AwwoEt5TQryEHwiKRVjz7Vk6kaBeD3/kwHE5YqTGHtm/JZY8Bo9ITOeKutFaXnBlMgSATMJALUQ==",
+      "version": "5.14.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.14.0.tgz",
+      "integrity": "sha512-EHwlII5mvUA0UsKYnVzySb/5EE/t03duUTweVy8Zqt3UQXBrpEVY144OTceFKaOe4xQXZJrkptCf7PjEBeGK4w==",
       "dev": true,
       "dependencies": {
         "@types/json-schema": "^7.0.9",
-        "@typescript-eslint/scope-manager": "5.13.0",
-        "@typescript-eslint/types": "5.13.0",
-        "@typescript-eslint/typescript-estree": "5.13.0",
+        "@typescript-eslint/scope-manager": "5.14.0",
+        "@typescript-eslint/types": "5.14.0",
+        "@typescript-eslint/typescript-estree": "5.14.0",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^3.0.0"
       },
@@ -1895,12 +1895,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.13.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.13.0.tgz",
-      "integrity": "sha512-HLKEAS/qA1V7d9EzcpLFykTePmOQqOFim8oCvhY3pZgQ8Hi38hYpHd9e5GN6nQBFQNecNhws5wkS9Y5XIO0s/g==",
+      "version": "5.14.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.14.0.tgz",
+      "integrity": "sha512-yL0XxfzR94UEkjBqyymMLgCBdojzEuy/eim7N9/RIcTNxpJudAcqsU8eRyfzBbcEzGoPWfdM3AGak3cN08WOIw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.13.0",
+        "@typescript-eslint/types": "5.14.0",
         "eslint-visitor-keys": "^3.0.0"
       },
       "engines": {
@@ -2348,9 +2348,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001313",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001313.tgz",
-      "integrity": "sha512-rI1UN0koZUiKINjysQDuRi2VeSCce3bYJNmDcj3PIKREiAmjakugBul1QSkg/fPrlULYl6oWfGg3PbgOSY9X4Q==",
+      "version": "1.0.30001314",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001314.tgz",
+      "integrity": "sha512-0zaSO+TnCHtHJIbpLroX7nsD+vYuOVjl3uzFbJO1wMVbuveJA0RK2WcQA9ZUIOiO0/ArMiMgHJLxfEZhQiC0kw==",
       "dev": true,
       "funding": {
         "type": "opencollective",
@@ -2654,9 +2654,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.76",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.76.tgz",
-      "integrity": "sha512-3Vftv7cenJtQb+k00McEBZ2vVmZ/x+HEF7pcZONZIkOsESqAqVuACmBxMv0JhzX7u0YltU0vSqRqgBSTAhFUjA==",
+      "version": "1.4.80",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.80.tgz",
+      "integrity": "sha512-COsbJCGVYCc/aAY4cd94x1Js3q0r406YKGbdL8LXHg0O9dEjuFEFU/vZneRxBxKo/f1lLHi0YyAR7sbFM+i8Bg==",
       "dev": true
     },
     "node_modules/emittery": {
@@ -6895,9 +6895,9 @@
       }
     },
     "@azure/core-lro": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/@azure/core-lro/-/core-lro-2.2.3.tgz",
-      "integrity": "sha512-UMdlR9NsqDCLTba3EUbRjfMF4gDmWvld196JmUjbz9WWhJ2XT00OR5MXeWiR+vmGT+ETiO4hHFCi2/eGO5YVtg==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/@azure/core-lro/-/core-lro-2.2.4.tgz",
+      "integrity": "sha512-e1I2v2CZM0mQo8+RSix0x091Av493e4bnT22ds2fcQGslTHzM2oTbswkB65nP4iEpCxBrFxOSDPKExmTmjCVtQ==",
       "requires": {
         "@azure/abort-controller": "^1.0.0",
         "@azure/core-tracing": "1.0.0-preview.13",
@@ -8107,14 +8107,14 @@
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "5.13.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.13.0.tgz",
-      "integrity": "sha512-vLktb2Uec81fxm/cfz2Hd6QaWOs8qdmVAZXLdOBX6JFJDhf6oDZpMzZ4/LZ6SFM/5DgDcxIMIvy3F+O9yZBuiQ==",
+      "version": "5.14.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.14.0.tgz",
+      "integrity": "sha512-ir0wYI4FfFUDfLcuwKzIH7sMVA+db7WYen47iRSaCGl+HMAZI9fpBwfDo45ZALD3A45ZGyHWDNLhbg8tZrMX4w==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "5.13.0",
-        "@typescript-eslint/type-utils": "5.13.0",
-        "@typescript-eslint/utils": "5.13.0",
+        "@typescript-eslint/scope-manager": "5.14.0",
+        "@typescript-eslint/type-utils": "5.14.0",
+        "@typescript-eslint/utils": "5.14.0",
         "debug": "^4.3.2",
         "functional-red-black-tree": "^1.0.1",
         "ignore": "^5.1.8",
@@ -8124,52 +8124,52 @@
       }
     },
     "@typescript-eslint/parser": {
-      "version": "5.13.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.13.0.tgz",
-      "integrity": "sha512-GdrU4GvBE29tm2RqWOM0P5QfCtgCyN4hXICj/X9ibKED16136l9ZpoJvCL5pSKtmJzA+NRDzQ312wWMejCVVfg==",
+      "version": "5.14.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.14.0.tgz",
+      "integrity": "sha512-aHJN8/FuIy1Zvqk4U/gcO/fxeMKyoSv/rS46UXMXOJKVsLQ+iYPuXNbpbH7cBLcpSbmyyFbwrniLx5+kutu1pw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "5.13.0",
-        "@typescript-eslint/types": "5.13.0",
-        "@typescript-eslint/typescript-estree": "5.13.0",
+        "@typescript-eslint/scope-manager": "5.14.0",
+        "@typescript-eslint/types": "5.14.0",
+        "@typescript-eslint/typescript-estree": "5.14.0",
         "debug": "^4.3.2"
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "5.13.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.13.0.tgz",
-      "integrity": "sha512-T4N8UvKYDSfVYdmJq7g2IPJYCRzwtp74KyDZytkR4OL3NRupvswvmJQJ4CX5tDSurW2cvCc1Ia1qM7d0jpa7IA==",
+      "version": "5.14.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.14.0.tgz",
+      "integrity": "sha512-LazdcMlGnv+xUc5R4qIlqH0OWARyl2kaP8pVCS39qSL3Pd1F7mI10DbdXeARcE62sVQE4fHNvEqMWsypWO+yEw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.13.0",
-        "@typescript-eslint/visitor-keys": "5.13.0"
+        "@typescript-eslint/types": "5.14.0",
+        "@typescript-eslint/visitor-keys": "5.14.0"
       }
     },
     "@typescript-eslint/type-utils": {
-      "version": "5.13.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.13.0.tgz",
-      "integrity": "sha512-/nz7qFizaBM1SuqAKb7GLkcNn2buRdDgZraXlkhz+vUGiN1NZ9LzkA595tHHeduAiS2MsHqMNhE2zNzGdw43Yg==",
+      "version": "5.14.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.14.0.tgz",
+      "integrity": "sha512-d4PTJxsqaUpv8iERTDSQBKUCV7Q5yyXjqXUl3XF7Sd9ogNLuKLkxz82qxokqQ4jXdTPZudWpmNtr/JjbbvUixw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/utils": "5.13.0",
+        "@typescript-eslint/utils": "5.14.0",
         "debug": "^4.3.2",
         "tsutils": "^3.21.0"
       }
     },
     "@typescript-eslint/types": {
-      "version": "5.13.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.13.0.tgz",
-      "integrity": "sha512-LmE/KO6DUy0nFY/OoQU0XelnmDt+V8lPQhh8MOVa7Y5k2gGRd6U9Kp3wAjhB4OHg57tUO0nOnwYQhRRyEAyOyg==",
+      "version": "5.14.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.14.0.tgz",
+      "integrity": "sha512-BR6Y9eE9360LNnW3eEUqAg6HxS9Q35kSIs4rp4vNHRdfg0s+/PgHgskvu5DFTM7G5VKAVjuyaN476LCPrdA7Mw==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "5.13.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.13.0.tgz",
-      "integrity": "sha512-Q9cQow0DeLjnp5DuEDjLZ6JIkwGx3oYZe+BfcNuw/POhtpcxMTy18Icl6BJqTSd+3ftsrfuVb7mNHRZf7xiaNA==",
+      "version": "5.14.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.14.0.tgz",
+      "integrity": "sha512-QGnxvROrCVtLQ1724GLTHBTR0lZVu13izOp9njRvMkCBgWX26PKvmMP8k82nmXBRD3DQcFFq2oj3cKDwr0FaUA==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.13.0",
-        "@typescript-eslint/visitor-keys": "5.13.0",
+        "@typescript-eslint/types": "5.14.0",
+        "@typescript-eslint/visitor-keys": "5.14.0",
         "debug": "^4.3.2",
         "globby": "^11.0.4",
         "is-glob": "^4.0.3",
@@ -8178,26 +8178,26 @@
       }
     },
     "@typescript-eslint/utils": {
-      "version": "5.13.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.13.0.tgz",
-      "integrity": "sha512-+9oHlPWYNl6AwwoEt5TQryEHwiKRVjz7Vk6kaBeD3/kwHE5YqTGHtm/JZY8Bo9ITOeKutFaXnBlMgSATMJALUQ==",
+      "version": "5.14.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.14.0.tgz",
+      "integrity": "sha512-EHwlII5mvUA0UsKYnVzySb/5EE/t03duUTweVy8Zqt3UQXBrpEVY144OTceFKaOe4xQXZJrkptCf7PjEBeGK4w==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.9",
-        "@typescript-eslint/scope-manager": "5.13.0",
-        "@typescript-eslint/types": "5.13.0",
-        "@typescript-eslint/typescript-estree": "5.13.0",
+        "@typescript-eslint/scope-manager": "5.14.0",
+        "@typescript-eslint/types": "5.14.0",
+        "@typescript-eslint/typescript-estree": "5.14.0",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^3.0.0"
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "5.13.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.13.0.tgz",
-      "integrity": "sha512-HLKEAS/qA1V7d9EzcpLFykTePmOQqOFim8oCvhY3pZgQ8Hi38hYpHd9e5GN6nQBFQNecNhws5wkS9Y5XIO0s/g==",
+      "version": "5.14.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.14.0.tgz",
+      "integrity": "sha512-yL0XxfzR94UEkjBqyymMLgCBdojzEuy/eim7N9/RIcTNxpJudAcqsU8eRyfzBbcEzGoPWfdM3AGak3cN08WOIw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.13.0",
+        "@typescript-eslint/types": "5.14.0",
         "eslint-visitor-keys": "^3.0.0"
       }
     },
@@ -8527,9 +8527,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001313",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001313.tgz",
-      "integrity": "sha512-rI1UN0koZUiKINjysQDuRi2VeSCce3bYJNmDcj3PIKREiAmjakugBul1QSkg/fPrlULYl6oWfGg3PbgOSY9X4Q==",
+      "version": "1.0.30001314",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001314.tgz",
+      "integrity": "sha512-0zaSO+TnCHtHJIbpLroX7nsD+vYuOVjl3uzFbJO1wMVbuveJA0RK2WcQA9ZUIOiO0/ArMiMgHJLxfEZhQiC0kw==",
       "dev": true
     },
     "chalk": {
@@ -8770,9 +8770,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.4.76",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.76.tgz",
-      "integrity": "sha512-3Vftv7cenJtQb+k00McEBZ2vVmZ/x+HEF7pcZONZIkOsESqAqVuACmBxMv0JhzX7u0YltU0vSqRqgBSTAhFUjA==",
+      "version": "1.4.80",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.80.tgz",
+      "integrity": "sha512-COsbJCGVYCc/aAY4cd94x1Js3q0r406YKGbdL8LXHg0O9dEjuFEFU/vZneRxBxKo/f1lLHi0YyAR7sbFM+i8Bg==",
       "dev": true
     },
     "emittery": {


### PR DESCRIPTION
Updated dependency tree for the lock file of your node project. 

By regenerating the lockfiles, the dependency tree has been updated to pull in the latest packages that match the dependency ranges in `package.json`. For each of those dependencies, the sub-dependencies are updated and so on. 

None of these updates should be a breaking change, since they respect the [version ranges](https://semver.npmjs.com/). They'll potentially save you and your team a lot of time by preventing `Dependabot` vulnerability alerts that you'd have to deal with manually otherwise. 

Good luck!

_This workflow was created and is maintained by the [Developer Productivity](https://tradeshift.slack.com/archives/C78TDU0FJ) team._