### PR TITLE
use qemu image from logged in registry

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -33,7 +33,7 @@ async function run(): Promise<void> {
       return;
     }
     if (inputs.useqemu) {
-      await qemu.setup();
+      await qemu.setup(registry);
     }
 
     await cache.restore(inputs);

--- a/src/qemu.ts
+++ b/src/qemu.ts
@@ -1,13 +1,13 @@
 import {endGroup, startGroup, warning} from '@actions/core';
 import {getExecOutput} from '@actions/exec';
 
-export async function setup(): Promise<void> {
+export async function setup(registry: string): Promise<void> {
   startGroup(`🖥️ Setup qemu`);
   const res = await getExecOutput('docker', [
     'run',
     '--privileged',
     '--rm',
-    'eu.gcr.io/tradeshift-base/tonistiigi/binfmt:qemu-v6.1.0',
+    `${registry}/tradeshift-base/tonistiigi/binfmt:qemu-v6.1.0`,
     '--install',
     'all'
   ]);


### PR DESCRIPTION
Building and pushing to the CN registry fails because it doesn't have credentials to fetch the qemu image from GCR registry.

https://github.com/Tradeshift/fintech-provider-integrations/runs/6764853041?check_suite_focus=true