### PR TITLE
chore: update dependency tree

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2467,9 +2467,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001400",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001400.tgz",
-      "integrity": "sha512-Mv659Hn65Z4LgZdJ7ge5JTVbE3rqbJaaXgW5LEI9/tOaXclfIZ8DW7D7FCWWWmWiiPS7AC48S8kf3DApSxQdgA==",
+      "version": "1.0.30001406",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001406.tgz",
+      "integrity": "sha512-bWTlaXUy/rq0BBtYShc/jArYfBPjEV95euvZ8JVtO43oQExEN/WquoqpufFjNu4kSpi5cy5kMbNvzztWDfv1Jg==",
       "dev": true,
       "funding": [
         {
@@ -2590,9 +2590,9 @@
       }
     },
     "node_modules/core-js-pure": {
-      "version": "3.25.1",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.25.1.tgz",
-      "integrity": "sha512-7Fr74bliUDdeJCBMxkkIuQ4xfxn/SwrVg+HkJUAoNEXVqYLv55l6Af0dJ5Lq2YBUW9yKqSkLXaS5SYPK6MGa/A==",
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.25.2.tgz",
+      "integrity": "sha512-ItD7YpW1cUB4jaqFLZXe1AXkyqIxz6GqPnsDV4uF4hVcWh/WAGIqSqw5p0/WdsILM0Xht9s3Koyw05R3K6RtiA==",
       "dev": true,
       "hasInstallScript": true,
       "funding": {
@@ -2681,9 +2681,9 @@
       }
     },
     "node_modules/decimal.js": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.0.tgz",
-      "integrity": "sha512-Nv6ENEzyPQ6AItkGwLE2PGKinZZ9g59vSh2BeH6NqPu0OTKZ5ruJsVqh/orbAnqXc9pBbgXAIrc2EyaCj8NpGg==",
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.1.tgz",
+      "integrity": "sha512-F29o+vci4DodHYT9UrR5IEbfBw9pE5eSapIJdTqXK5+6hq+t8VRxwQyKlW2i+KDKFkkJQRvFyI/QXD83h8LyQw==",
       "dev": true
     },
     "node_modules/dedent": {
@@ -2800,9 +2800,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.251",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.251.tgz",
-      "integrity": "sha512-k4o4cFrWPv4SoJGGAydd07GmlRVzmeDIJ6MaEChTUjk4Dmomn189tCicSzil2oyvbPoGgg2suwPDNWq4gWRhoQ==",
+      "version": "1.4.254",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.254.tgz",
+      "integrity": "sha512-Sh/7YsHqQYkA6ZHuHMy24e6TE4eX6KZVsZb9E/DvU1nQRIrH4BflO/4k+83tfdYvDl+MObvlqHPRICzEdC9c6Q==",
       "dev": true
     },
     "node_modules/emittery": {
@@ -8986,9 +8986,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001400",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001400.tgz",
-      "integrity": "sha512-Mv659Hn65Z4LgZdJ7ge5JTVbE3rqbJaaXgW5LEI9/tOaXclfIZ8DW7D7FCWWWmWiiPS7AC48S8kf3DApSxQdgA==",
+      "version": "1.0.30001406",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001406.tgz",
+      "integrity": "sha512-bWTlaXUy/rq0BBtYShc/jArYfBPjEV95euvZ8JVtO43oQExEN/WquoqpufFjNu4kSpi5cy5kMbNvzztWDfv1Jg==",
       "dev": true
     },
     "chalk": {
@@ -9080,9 +9080,9 @@
       }
     },
     "core-js-pure": {
-      "version": "3.25.1",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.25.1.tgz",
-      "integrity": "sha512-7Fr74bliUDdeJCBMxkkIuQ4xfxn/SwrVg+HkJUAoNEXVqYLv55l6Af0dJ5Lq2YBUW9yKqSkLXaS5SYPK6MGa/A==",
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.25.2.tgz",
+      "integrity": "sha512-ItD7YpW1cUB4jaqFLZXe1AXkyqIxz6GqPnsDV4uF4hVcWh/WAGIqSqw5p0/WdsILM0Xht9s3Koyw05R3K6RtiA==",
       "dev": true
     },
     "cross-spawn": {
@@ -9151,9 +9151,9 @@
       }
     },
     "decimal.js": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.0.tgz",
-      "integrity": "sha512-Nv6ENEzyPQ6AItkGwLE2PGKinZZ9g59vSh2BeH6NqPu0OTKZ5ruJsVqh/orbAnqXc9pBbgXAIrc2EyaCj8NpGg==",
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.1.tgz",
+      "integrity": "sha512-F29o+vci4DodHYT9UrR5IEbfBw9pE5eSapIJdTqXK5+6hq+t8VRxwQyKlW2i+KDKFkkJQRvFyI/QXD83h8LyQw==",
       "dev": true
     },
     "dedent": {
@@ -9242,9 +9242,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.4.251",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.251.tgz",
-      "integrity": "sha512-k4o4cFrWPv4SoJGGAydd07GmlRVzmeDIJ6MaEChTUjk4Dmomn189tCicSzil2oyvbPoGgg2suwPDNWq4gWRhoQ==",
+      "version": "1.4.254",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.254.tgz",
+      "integrity": "sha512-Sh/7YsHqQYkA6ZHuHMy24e6TE4eX6KZVsZb9E/DvU1nQRIrH4BflO/4k+83tfdYvDl+MObvlqHPRICzEdC9c6Q==",
       "dev": true
     },
     "emittery": {


### PR DESCRIPTION
Updated dependency tree for the lock file of your node project. 

By regenerating the lockfiles, the dependency tree has been updated to pull in the latest packages that match the dependency ranges in `package.json`. For each of those dependencies, the sub-dependencies are updated and so on. 

None of these updates should be a breaking change, since they respect the [version ranges](https://semver.npmjs.com/). They'll potentially save you and your team a lot of time by preventing `Dependabot` vulnerability alerts that you'd have to deal with manually otherwise. 

Good luck!

_This workflow was created and is maintained by the [Developer Productivity](https://tradeshift.slack.com/archives/C78TDU0FJ) team._