### PR TITLE
fix: specifying runner type

### DIFF
--- a/.github/workflows/dependency-tree-update.yml
+++ b/.github/workflows/dependency-tree-update.yml
@@ -13,4 +13,4 @@ jobs:
       npm-token: ${{ secrets.NPM_TOKEN }} # Token used to authenticate to the private GitHub npm registry
     with:
       path: . # Optional paramater in case your application is not at the root of your, otherwise it defaults to "."
-      # runs-on: self-hosted # Optional paramater to define where to run the workflow, otherwise it defaults to ubuntu-latest. More information at https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idruns-on
+      # runs-on: [self-hosted,ts-large-x64-docker-large] # Optional paramater to define where to run the workflow, otherwise it defaults to ubuntu-latest. More information at https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idruns-on


### PR DESCRIPTION
This pull request specifies a runner type for workflows on your repo that are missing it. Having only `runs-on: self-hosted`could cause unexpected behavior, making your workflow run on a runner that you didn't intend.

Soon this change will be mandatory, and any workflows with only `runs-on: self-hosted` will not work anymore.  
	
You can read more about the available runner types [here](https://github.com/Tradeshift/actions-runner-autoscaler#available-runners).