### PR TITLE
chore: fix using postUpgradeTasks

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,9 +5,11 @@
   ],
   "postUpgradeTasks": {
     "commands": [
+      "npm ci --ignore-scripts",
       "npm run --if-present format",
       "npm run --if-present build",
       "npm run --if-present package"
-    ]
+    ],
+    "executionMode": "branch"
   }
 }


### PR DESCRIPTION
It seems the node modules are not available without running `npm install` as part of the upgrade commands.
This means we cannot use it in the shared config, or would have to add guards to check if `package.json` exists.