### PR TITLE
fix: disable tagging with prefix

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -75,6 +75,7 @@ inputs:
       based on the type of build: on master or on pull rquest.
       An image built from a pull request is tagged with pr-<number>-<SHA>.
       An image built on merge to master branch is tagged with master-<SHA>.
+    default: true 
   useqemu:
     required: false
     description: >


### PR DESCRIPTION
This commit disables tagging with prefix.
I need to figure out how to make it work
on a [scheduled ](https://github.com/Tradeshift/tradeshift-docker-base/actions/runs/7549782306)workflow.